### PR TITLE
Upgrade JUnit to 6.0.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ guava = "33.5.0-jre"
 immutables = "2.12.1"
 commons-io = "2.21.0"
 commons-lang3 = "3.20.0"
-junit = "5.14.3"
+junit = "6.0.3"
 log4j = "2.25.3"
 slf4j = "2.0.17"
 


### PR DESCRIPTION
## Summary
- Upgrade junit-jupiter from 5.14.3 to 6.0.3 (latest stable)
- All other dependencies are already at their latest versions

## Notes
- JUnit 6 requires Java 17+ (project uses Java 21, no issue)
- Maintains same org.junit.jupiter package structure
- All tests pass with new version